### PR TITLE
feat(ledger): updated ledger signing to work with Generic and Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,22 @@ zombienet is the preferred choice.
 	* Signatories out of order - Need to order the passed through signatories 
 
 
-## Ledger Support 
+## Ledger Support
 
-* To interact with the ledger first you need to install the Ledger applications for [Kusama Asset Hub](https://github.com/Zondax/ledger-statemine) and [Polkadot Asset Hub](https://github.com/Zondax/ledger-statemint) from Ledger Live.
+* [Ledger has released an app](https://forum.polkadot.network/t/new-polkadot-ledger-app/8817) to be used for every chain of the Polkadot Ecosystem. This removes the need to have a specific application for every chain, but it cannot be used for accounts generated through the old apps, therefore if you still have funds on the old accounts, you need to [migrate them](https://docs.novawallet.io/nova-wallet-wiki/wallet-management/hardware-wallets/ledger-nano-x/ledger-app-migration) to the new accounts.
+
+### Ledger Generic App Support 
+
+* To interact with the ledger first you need to install the Ledger Polkadot Generic App from Ledger Live.
 
 * To use the Ledger just type ledger instead of inputting a mnemonic.
+
+
+### Ledger Migration App Support 
+
+* In order to move funds from your old account to the new one as to use the new Polkadot Generic App, you need to install the Ledger Migration App from Ledger Live.
+
+* Then to use the Ledger Migration App, you need to type migration instead of inputting a mnemonic.
 
 
 ## Running from a fresh machine 

--- a/blockchainServices/palletCalls/approveMultisigTx.js
+++ b/blockchainServices/palletCalls/approveMultisigTx.js
@@ -34,7 +34,7 @@ const question = [
   {
     type: 'input',
     name: 'admin',
-    message: 'sender of the transaction (type ledger to use Ledger)',
+    message: 'sender of the transaction (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Bob',
   },
   {
@@ -145,6 +145,8 @@ const approveMultisigTx = async (calls) => {
   );
   if (admin === 'ledger') {
     await ledgerSignAndSend(tx, api);
+  } else if (admin === 'migration') {
+    await ledgerSignAndSend(tx, api, true);
   } else {
     sender = getKeypair(admin);
     await signAndSend(tx, api, sender);

--- a/blockchainServices/palletCalls/approveTransfer.js
+++ b/blockchainServices/palletCalls/approveTransfer.js
@@ -34,6 +34,8 @@ const approveTransfer = async (calls) => {
   const tx = await calls.approveTransfer(api, [id, delegate, amount])
   if (from === 'ledger') {
     await ledgerSignAndSend(tx, api)
+  } else if (from === 'migration') {
+    await ledgerSignAndSend(tx, api, true)
   } else {
     const sender = getKeypair(from);
     await signAndSend(tx, api, sender)

--- a/blockchainServices/palletCalls/approveTransfer.js
+++ b/blockchainServices/palletCalls/approveTransfer.js
@@ -11,7 +11,7 @@ const question = [
   {
       type: 'input',
       name: 'from',
-      message: 'sending from mnemonic (type ledger to use Ledger)',
+      message: 'sending from mnemonic (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
       default: '//Bob' 
   },
   {

--- a/blockchainServices/palletCalls/batchBurn.js
+++ b/blockchainServices/palletCalls/batchBurn.js
@@ -34,6 +34,8 @@ const batchBurn = async (calls) => {
   const tx = await calls.batchBurn(api, [id, who, amount])
   if (admin === 'ledger') {
     await ledgerSignAndSend(tx, api)
+  } else if ( admin === 'migration') {
+    await ledgerSignAndSend(tx, api, true)
   } else {
     const sender = getKeypair(admin);
     await signAndSend(tx, api, sender)

--- a/blockchainServices/palletCalls/block.js
+++ b/blockchainServices/palletCalls/block.js
@@ -28,6 +28,8 @@ const block = async (calls) => {
   const tx = await calls.block(api, [id, who])
   if (blocker === 'ledger') {
     await ledgerSignAndSend(tx, api)
+  } else if (blocker === 'migration') {
+    await ledgerSignAndSend(tx, api, true)
   } else {
     const sender = getKeypair(blocker);
     await signAndSend(tx, api, sender)

--- a/blockchainServices/palletCalls/block.js
+++ b/blockchainServices/palletCalls/block.js
@@ -17,7 +17,7 @@ const question = [
   {
     type: 'input',
     name: 'blocker',
-    message: 'freezer for the asset (type ledger to use Ledger)',
+    message: 'freezer for the asset (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice' 
   }
 ];

--- a/blockchainServices/palletCalls/burn.js
+++ b/blockchainServices/palletCalls/burn.js
@@ -34,6 +34,8 @@ const burn = async (calls) => {
   const tx = await calls.burn(api, [id, who, amount])
   if (admin === 'ledger') {
     await ledgerSignAndSend(tx, api)
+  } else if (admin === 'migration') {
+    await ledgerSignAndSend(tx, api, true)
   } else {
     const sender = getKeypair(admin);
     await signAndSend(tx, api, sender)

--- a/blockchainServices/palletCalls/burn.js
+++ b/blockchainServices/palletCalls/burn.js
@@ -23,7 +23,7 @@ const question = [
   {
     type: 'input',
     name: 'admin',
-    message: 'admin for the asset (type ledger to use Ledger)',
+    message: 'admin for the asset (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice' 
   }
 ];

--- a/blockchainServices/palletCalls/cancelApproval.js
+++ b/blockchainServices/palletCalls/cancelApproval.js
@@ -28,6 +28,8 @@ const cancelApproval = async (calls) => {
   const tx = await calls.cancelApproval(api, [id, delegate])
   if (from === 'ledger') {
     await ledgerSignAndSend(tx, api)
+  } else if (from === 'migration') {
+    await ledgerSignAndSend(tx, api, true)
   } else {
     const sender = getKeypair(from);
     await signAndSend(tx, api, sender)

--- a/blockchainServices/palletCalls/cancelApproval.js
+++ b/blockchainServices/palletCalls/cancelApproval.js
@@ -11,7 +11,7 @@ const question = [
   {
     type: 'input',
     name: 'from',
-    message: 'sending from mnemonic (type ledger to use Ledger)',
+    message: 'sending from mnemonic (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Bob' 
 },
   {

--- a/blockchainServices/palletCalls/clearMetadata.js
+++ b/blockchainServices/palletCalls/clearMetadata.js
@@ -11,7 +11,7 @@ const question = [
   {
     type: 'input',
     name: 'admin',
-    message: 'admin for the asset (type ledger to use Ledger)',
+    message: 'admin for the asset (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice'
   }
 ];

--- a/blockchainServices/palletCalls/clearMetadata.js
+++ b/blockchainServices/palletCalls/clearMetadata.js
@@ -22,6 +22,8 @@ const clearMetadata = async (calls) => {
   const tx = await calls.clearMetadata(api, [Number(id)])
   if (admin === 'ledger') {
     await ledgerSignAndSend(tx, api)
+  } else if (admin === 'migration') {
+    await ledgerSignAndSend(tx, api, true)
   } else {
     const sender = getKeypair(admin);
     await signAndSend(tx, api, sender)

--- a/blockchainServices/palletCalls/createAsset.js
+++ b/blockchainServices/palletCalls/createAsset.js
@@ -11,7 +11,7 @@ const question = [
   {
     type: 'input',
     name: 'admin',
-    message: 'input admin mnemonic (type ledger to use Ledger)',
+    message: 'input admin mnemonic (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice',
   },
   {

--- a/blockchainServices/palletCalls/createAsset.js
+++ b/blockchainServices/palletCalls/createAsset.js
@@ -29,6 +29,8 @@ const createAsset = async (calls) => {
   const tx = await calls.createAsset(api, [id, sender.address, minBalance])
   if (admin === 'ledger') {
     await ledgerSignAndSend(tx, api)
+  } else if (admin === 'migration') {
+    await ledgerSignAndSend(tx, api, true)
   } else {
     await signAndSend(tx, api, sender)
   }

--- a/blockchainServices/palletCalls/createMultisigTx.js
+++ b/blockchainServices/palletCalls/createMultisigTx.js
@@ -33,7 +33,7 @@ const question = [
   {
     type: 'input',
     name: 'admin',
-    message: 'sender of the transaction (type ledger to use Ledger)',
+    message: 'sender of the transaction (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice',
   },
   {
@@ -136,6 +136,8 @@ const createMultisigTx = async (calls) => {
   );
   if (admin === 'ledger') {
     await ledgerSignAndSend(tx, api);
+  } else if (admin === 'migration') {
+    await ledgerSignAndSend(tx, api, true);
   } else {
     sender = getKeypair(admin);
     await signAndSend(tx, api, sender);

--- a/blockchainServices/palletCalls/destroy.js
+++ b/blockchainServices/palletCalls/destroy.js
@@ -11,13 +11,13 @@ const question = [
   {
     type: 'input',
     name: 'admin',
-    message: 'input admin mnemonic (type ledger to use Ledger)',
+    message: 'input admin mnemonic (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice',
   },
   {
     type: 'input',
     name: 'freezer',
-    message: 'input freezer mnemonic (type ledger to use Ledger)',
+    message: 'input freezer mnemonic (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice',
   }
 ];
@@ -36,6 +36,17 @@ const destroy = async (calls) => {
     await ledgerSignAndSendWithNonce(tx_3, api)
     const tx_4 = await calls.finishDestroy(api, [id])
     await ledgerSignAndSendWithNonceAndExit(tx_4, api)
+  } else if (admin === 'migration') {
+    const tx_0 = await calls.freezeAsset(api, [id])
+    await ledgerSignAndSendWithNonce(tx_0, api, true)
+    const tx_1 = await calls.startDestroy(api, [id])
+    await ledgerSignAndSendWithNonce(tx_1, api, true)
+    const tx_2 = await calls.destroyAccounts(api, [id])
+    await ledgerSignAndSendWithNonce(tx_2, api, true)
+    const tx_3 = await calls.destroyApprovals(api, [id])
+    await ledgerSignAndSendWithNonce(tx_3, api, true)
+    const tx_4 = await calls.finishDestroy(api, [id])
+    await ledgerSignAndSendWithNonceAndExit(tx_4, api, true)
   } else {
     const freezerPair = getKeypair(freezer);
     const tx_0 = await calls.freezeAsset(api, [id])

--- a/blockchainServices/palletCalls/forceTransfer.js
+++ b/blockchainServices/palletCalls/forceTransfer.js
@@ -11,7 +11,7 @@ const question = [
   {
     type: 'input',
     name: 'admin',
-    message: 'admin account (type ledger to use Ledger)',
+    message: 'admin account (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice',
   },
   {

--- a/blockchainServices/palletCalls/forceTransfer.js
+++ b/blockchainServices/palletCalls/forceTransfer.js
@@ -40,6 +40,8 @@ const forceTransfer = async (calls) => {
   const tx = await calls.forceTransfer(api, [id, source, dest, amount]);
   if (admin === 'ledger') {
     await ledgerSignAndSend(tx, api)
+  } else if (admin === 'migration') {
+    await ledgerSignAndSend(tx, api, true)
   } else {
     const sender = getKeypair(admin);
     await signAndSend(tx, api, sender)

--- a/blockchainServices/palletCalls/freeze.js
+++ b/blockchainServices/palletCalls/freeze.js
@@ -33,6 +33,8 @@ const freeze = async (calls) => {
   const tx = await calls.freeze(api, [id, who]);
   if (freezer === 'ledger') {
     await ledgerSignAndSend(tx, api);
+  } else if (freezer === 'migration') {
+    await ledgerSignAndSend(tx, api, true);
   } else {
     const sender = getKeypair(freezer);
     await signAndSend(tx, api, sender);

--- a/blockchainServices/palletCalls/freeze.js
+++ b/blockchainServices/palletCalls/freeze.js
@@ -22,7 +22,7 @@ const question = [
   {
     type: 'input',
     name: 'freezer',
-    message: 'input freezer mnemonic (type ledger to use Ledger)',
+    message: 'input freezer mnemonic (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice',
   },
 ];

--- a/blockchainServices/palletCalls/freezeAsset.js
+++ b/blockchainServices/palletCalls/freezeAsset.js
@@ -16,7 +16,7 @@ const question = [
   {
     type: 'input',
     name: 'freezer',
-    message: 'input freezer mnemonic (type ledger to use Ledger)',
+    message: 'input freezer mnemonic (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice',
   },
 ];

--- a/blockchainServices/palletCalls/freezeAsset.js
+++ b/blockchainServices/palletCalls/freezeAsset.js
@@ -27,6 +27,8 @@ const freezeAsset = async (calls) => {
   const tx = await calls.freezeAsset(api, [id]);
   if (freezer === 'ledger') {
     await ledgerSignAndSend(tx, api);
+  } else if (freezer === 'migration') {
+    await ledgerSignAndSend(tx, api, true);
   } else {
     const sender = getKeypair(freezer);
     await signAndSend(tx, api, sender);

--- a/blockchainServices/palletCalls/helpers/configHelpers.js
+++ b/blockchainServices/palletCalls/helpers/configHelpers.js
@@ -32,7 +32,7 @@ const multisigConfig = async (params) => {
     ? config.signatories
     : otherSignatories;
   admin = config.ledger ? "ledger" : config.admin;
-  const sender = config.ledger ? await getLedgerAddress() : getKeypair(admin);
+  const sender = config.ledger ? await getLedgerAddress(config.migration) : getKeypair(admin);
   otherSignatories = otherSignatories.filter((who) => who !== sender.address);
   otherSignatories.sort();
   console.log(

--- a/blockchainServices/palletCalls/mint.js
+++ b/blockchainServices/palletCalls/mint.js
@@ -33,6 +33,8 @@ const mint = async (calls) => {
   const tx = await calls.mint(api, [id, beneficiary, amount])
   if (issuer === 'ledger') {
     await ledgerSignAndSend(tx, api)
+  } else if (issuer === 'migration') {
+    await ledgerSignAndSend(tx, api, true)
   } else {
     const sender = getKeypair(issuer);
     await signAndSend(tx, api, sender)

--- a/blockchainServices/palletCalls/mint.js
+++ b/blockchainServices/palletCalls/mint.js
@@ -22,7 +22,7 @@ const question = [
   {
       type: 'input',
       name: 'issuer',
-      message: 'issuer for the asset (type ledger to use Ledger)',
+      message: 'issuer for the asset (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
       default: '//Alice'
   }
 ];

--- a/blockchainServices/palletCalls/setMetadata.js
+++ b/blockchainServices/palletCalls/setMetadata.js
@@ -29,7 +29,7 @@ const question = [
   {
     type: 'input',
     name: 'admin',
-    message: 'admin for the asset (type ledger to use Ledger)',
+    message: 'admin for the asset (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice',
   },
 ];

--- a/blockchainServices/palletCalls/setMetadata.js
+++ b/blockchainServices/palletCalls/setMetadata.js
@@ -40,6 +40,8 @@ const setMetadata = async (calls) => {
   const tx = await calls.setMetadata(api, [id, name, symbol, decimals]);
   if (admin === 'ledger') {
     await ledgerSignAndSend(tx, api)
+  } else if (admin === 'migration') {
+    await ledgerSignAndSend(tx, api, true)
   } else {
     const sender = getKeypair(admin);
     await signAndSend(tx, api, sender)

--- a/blockchainServices/palletCalls/setTeam.js
+++ b/blockchainServices/palletCalls/setTeam.js
@@ -46,6 +46,8 @@ const setTeam = async (calls) => {
   const tx = await calls.setTeam(api, [id, newIssuer, newAdmin, newFreezer]);
   if (currentAdmin === 'ledger') {
     await ledgerSignAndSend(tx, api);
+  } else if (currentAdmin === 'migration') {
+    await ledgerSignAndSend(tx, api, true);
   } else {
     const sender = getKeypair(currentAdmin);
     await signAndSend(tx, api, sender);

--- a/blockchainServices/palletCalls/setTeam.js
+++ b/blockchainServices/palletCalls/setTeam.js
@@ -16,7 +16,7 @@ const question = [
   {
     type: 'input',
     name: 'currentAdmin',
-    message: 'input current admin mnemonic (type ledger to use Ledger)',
+    message: 'input current admin mnemonic (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice',
   },
   {

--- a/blockchainServices/palletCalls/thaw.js
+++ b/blockchainServices/palletCalls/thaw.js
@@ -22,7 +22,7 @@ const question = [
   {
     type: 'input',
     name: 'admin',
-    message: 'input admin mnemonic (type ledger to use Ledger)',
+    message: 'input admin mnemonic (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice',
   },
 ];
@@ -33,6 +33,8 @@ const thaw = async (calls) => {
   const tx = await calls.thaw(api, [id, who]);
   if (admin === 'ledger') {
     await ledgerSignAndSend(tx, api);
+  } else if (admin === 'migration') {
+    await ledgerSignAndSend(tx, api, true);
   } else {
     const sender = getKeypair(admin);
     await signAndSend(tx, api, sender);

--- a/blockchainServices/palletCalls/thawAsset.js
+++ b/blockchainServices/palletCalls/thawAsset.js
@@ -11,7 +11,7 @@ const question = [
   {
     type: 'input',
     name: 'thawer',
-    message: 'input thawer mnemonic (type ledger to use Ledger)',
+    message: 'input thawer mnemonic (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice',
   },
 ];

--- a/blockchainServices/palletCalls/thawAsset.js
+++ b/blockchainServices/palletCalls/thawAsset.js
@@ -22,6 +22,8 @@ const thawAsset = async (calls) => {
   const tx = await calls.thawAsset(api, [id]);
   if (thawer === 'ledger') {
     await ledgerSignAndSend(tx, api);
+  } else if (thawer === 'migration') {
+    await ledgerSignAndSend(tx, api, true);
   } else {
     const sender = getKeypair(thawer);
     await signAndSend(tx, api, sender);

--- a/blockchainServices/palletCalls/touchOther.js
+++ b/blockchainServices/palletCalls/touchOther.js
@@ -28,6 +28,8 @@ const touchOther = async (calls) => {
   const tx = await calls.touchOther(api, [id, who])
   if (admin === 'ledger') {
     await ledgerSignAndSend(tx, api)
+  } else if (admin === 'migration') {
+    await ledgerSignAndSend(tx, api, true)
   } else {
     const sender = getKeypair(creator);
     await signAndSend(tx, api, sender)

--- a/blockchainServices/palletCalls/touchOther.js
+++ b/blockchainServices/palletCalls/touchOther.js
@@ -17,7 +17,7 @@ const question = [
   {
       type: 'input',
       name: 'creator',
-      message: 'admin or freezer for the asset (type ledger to use Ledger)',
+      message: 'admin or freezer for the asset (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
       default: '//Alice' 
   }
 ];

--- a/blockchainServices/palletCalls/transfer.js
+++ b/blockchainServices/palletCalls/transfer.js
@@ -34,6 +34,8 @@ const transfer = async (calls) => {
   const tx = await calls.transfer(api, [id, to, amount]);
   if (from === 'ledger') {
     await ledgerSignAndSend(tx, api);
+  } else if (from === 'migration') {
+    await ledgerSignAndSend(tx, api, true);
   } else {
     const sender = getKeypair(from);
     await signAndSend(tx, api, sender);

--- a/blockchainServices/palletCalls/transfer.js
+++ b/blockchainServices/palletCalls/transfer.js
@@ -11,7 +11,7 @@ const question = [
   {
     type: 'input',
     name: 'from',
-    message: 'sending from mnemonic (type ledger to use Ledger)',
+    message: 'sending from mnemonic (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice',
   },
   {

--- a/blockchainServices/palletCalls/transferApproved.js
+++ b/blockchainServices/palletCalls/transferApproved.js
@@ -29,7 +29,7 @@ const question = [
   {
     type: 'input',
     name: 'origin',
-    message: 'mnemonic sending from (type ledger to use Ledger)',
+    message: 'mnemonic sending from (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice',
   },
 ];

--- a/blockchainServices/palletCalls/transferApproved.js
+++ b/blockchainServices/palletCalls/transferApproved.js
@@ -40,6 +40,8 @@ const transferApproved = async (calls) => {
   const tx = await calls.transferApproved(api, [id, from, to, amount]);
   if (origin === 'ledger') {
     await ledgerSignAndSend(tx, api)
+  } else if (origin === 'migration') {
+    await ledgerSignAndSend(tx, api, true)
   } else {
     const sender = getKeypair(origin);
     await signAndSend(tx, api, sender)

--- a/blockchainServices/palletCalls/transferKeepAlive.js
+++ b/blockchainServices/palletCalls/transferKeepAlive.js
@@ -34,6 +34,8 @@ const transferKeepAlive = async (calls) => {
   const tx = await calls.transferKeepAlive(api, [id, target, amount]);
   if (from === 'ledger') {
     await ledgerSignAndSend(tx, api);
+  } else if (from === 'migration') {
+    await ledgerSignAndSend(tx, api, true);
   } else {
     const sender = getKeypair(from);
     await signAndSend(tx, api, sender);

--- a/blockchainServices/palletCalls/transferKeepAlive.js
+++ b/blockchainServices/palletCalls/transferKeepAlive.js
@@ -11,7 +11,7 @@ const question = [
   {
     type: 'input',
     name: 'from',
-    message: 'sending from mnemonic (type ledger to use Ledger)',
+    message: 'sending from mnemonic (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice',
   },
   {

--- a/blockchainServices/palletCalls/transferNative.js
+++ b/blockchainServices/palletCalls/transferNative.js
@@ -34,6 +34,8 @@ const transferNative = async (calls) => {
   const tx = await calls.transferNative(api, [target, adjustedAmount]);
   if (from === 'ledger') {
     await ledgerSignAndSend(tx, api);
+  } else  if (from === 'migration') {
+    await ledgerSignAndSend(tx, api, true);
   } else {
     const sender = getKeypair(from);
     await signAndSend(tx, api, sender);

--- a/blockchainServices/palletCalls/transferNative.js
+++ b/blockchainServices/palletCalls/transferNative.js
@@ -10,7 +10,7 @@ const question = [
   {
     type: 'input',
     name: 'from',
-    message: 'sending from mnemonic (type ledger to use Ledger)',
+    message: 'sending from mnemonic (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice',
   },
   {

--- a/blockchainServices/palletCalls/transferOwnership.js
+++ b/blockchainServices/palletCalls/transferOwnership.js
@@ -16,7 +16,7 @@ const question = [
   {
     type: 'input',
     name: 'admin',
-    message: 'input current owner mnemonic (type ledger to use Ledger)',
+    message: 'input current owner mnemonic (type ledger to use Ledger Generic App, type migration to use Ledger Migration App)',
     default: '//Alice',
   },
   {
@@ -33,6 +33,8 @@ const transferOwnership = async (calls) => {
   const tx = await calls.transferOwnership(api, [id, owner]);
   if (admin === 'ledger') {
     await ledgerSignAndSend(tx, api);
+  } else if (admin === 'migration') {
+    await ledgerSignAndSend(tx, api, true);
   } else {
     const sender = getKeypair(admin);
     await signAndSend(tx, api, sender);

--- a/blockchainServices/setup.ts
+++ b/blockchainServices/setup.ts
@@ -57,12 +57,12 @@ const getNetwork = async () => {
 	return network;
 }
 
-const getLedgerAddress = async () => {
+const getLedgerAddress = async (migration = false) => {
 	const api = await getApi();
 	const network = await getNetwork();
-	const ledger = new LedgerGeneric('hid', network, knownLedger['polkadot']);
+	const ledger = migration ? new LedgerGeneric('hid', network, knownLedger[network]) : new LedgerGeneric('hid', network, knownLedger['polkadot']);
 	const ss58 = api.consts.system.ss58Prefix.toNumber();
-
+	
 	return await ledger.getAddress(ss58, false, ledger.accountOffset, ledger.addressOffset);
 };
 

--- a/blockchainServices/setup.ts
+++ b/blockchainServices/setup.ts
@@ -93,7 +93,7 @@ class LedgerSigner implements Signer {
 		const m = await this.#api.call.metadata.metadataAtVersion(15);
 		const { specName, specVersion } = this.#api.runtimeVersion;
 		const merkleizedMetadata = merkleizeMetadata(m.toHex(), {
-		  base58Prefix: Number(this.#api.consts.system.ss58Prefix),
+		  base58Prefix: (this.#api as any).consts.system.ss58Prefix.toNumber(),
 		  decimals: this.#api.registry.chainDecimals[0],
 		  specName: specName.toString(),
 		  specVersion: specVersion.toNumber(),
@@ -101,7 +101,6 @@ class LedgerSigner implements Signer {
 		});
 		const metadataHash = u8aToHex(merkleizedMetadata.digest());
 		const newPayload = objectSpread({}, payload, { withSignedTransaction: true, metadataHash, mode: 1 });
-		console.log('newPayload: ', newPayload);
 		const raw = this.#registry.createType('ExtrinsicPayload', newPayload);
 	
 		return {
@@ -113,7 +112,7 @@ class LedgerSigner implements Signer {
 	public async signPayload(payload: SignerPayloadJSON): Promise<SignerResult> {
 
 		const { address } = await this.#getLedger.getAddress(
-			Number(this.#api.consts.system.ss58Prefix),
+			(this.#api as any).consts.system.ss58Prefix.toNumber(),
 			false,
 			this.#accountOffset,
 			this.#addressOffset
@@ -145,7 +144,7 @@ class LedgerSigner implements Signer {
 
 
 const ledgerSignAndSend = async (call: any, api: any, migration = false) => {
-	console.log('\nsending ledger transaction');
+	console.log('sending transaction to ledger\n');
 	
 	const network = await getNetwork();
 
@@ -184,7 +183,7 @@ const ledgerSignAndSend = async (call: any, api: any, migration = false) => {
 };
 
 const ledgerSignAndSendWithNonce = async (call: any, api: any, migration = false) => {
-	console.log('\nsending ledger transaction');
+	console.log('sending transaction to ledger\n');
 
 	const network = await getNetwork();
 
@@ -223,7 +222,7 @@ const ledgerSignAndSendWithNonce = async (call: any, api: any, migration = false
 };
 
 const ledgerSignAndSendWithNonceAndExit = async (call: any, api: any, migration = false) => {
-	console.log('\nsending ledger transaction');
+	console.log('\nsending transaction to ledger');
 
 	const network = await getNetwork();
 	
@@ -264,7 +263,7 @@ const ledgerSignAndSendWithNonceAndExit = async (call: any, api: any, migration 
 };
 
 const signAndSend = (call: any, api: any, sender: any) => {
-	console.log('sending transaction');
+	console.log('\nsending transaction');
 	call.signAndSend(sender, ({ status, dispatchError }: any) => {
 		// status would still be set, but in the case of error we can shortcut
 		// to just check it (so an error would indicate InBlock or Finalized)

--- a/blockchainServices/setup.ts
+++ b/blockchainServices/setup.ts
@@ -153,7 +153,6 @@ const ledgerSignAndSend = async (call: any, api: any, migration = false) => {
 	
 	const ledger = migration ? new LedgerGeneric('hid', network, knownLedger[network]) : new LedgerGeneric('hid', network, knownLedger['polkadot']);
 	const sender = await ledger.getAddress(ss58, false, ledger.accountOffset, ledger.addressOffset);
-	console.log({ sender });
 	const ledgerSigner = new LedgerSigner(api, api.registry, ledger, 0, 0);
 	const signAsync = await call.signAsync(sender.address, {
 		signer: ledgerSigner,
@@ -193,7 +192,6 @@ const ledgerSignAndSendWithNonce = async (call: any, api: any, migration = false
 	
 	const ledger = migration ? new LedgerGeneric('hid', network, knownLedger[network]) : new LedgerGeneric('hid', network, knownLedger['polkadot']);
 	const sender = await ledger.getAddress(ss58, false, ledger.accountOffset, ledger.addressOffset);;
-	console.log({ sender });
 	const ledgerSigner = new LedgerSigner(api, api.registry, ledger, 0, 0);
 	const signAsync = await call.signAsync(sender.address, {
 		nonce: -1,
@@ -234,7 +232,6 @@ const ledgerSignAndSendWithNonceAndExit = async (call: any, api: any, migration 
 	const ledger = migration ? new LedgerGeneric('hid', network, knownLedger[network]) : new LedgerGeneric('hid', network, knownLedger['polkadot']);
 
 	const sender = await ledger.getAddress(ss58, false, ledger.accountOffset, ledger.addressOffset);;
-	console.log({ sender });
 	const ledgerSigner = new LedgerSigner(api, api.registry, ledger, 0, 0);
 	const signAsync = await call.signAsync(sender.address, {
 		nonce: -1,

--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ const main = async () => {
     case 'Native Balance':
       await nativeBalance(calls);
       break;
-    case 'Display Ledger Address (only compatible with Ledger Generic App)':
+    case 'Display Ledger Address (Ledger Generic App)':
       console.log(await getLedgerAddress());
       break;
     default:

--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ const main = async () => {
     case 'Native Balance':
       await nativeBalance(calls);
       break;
-    case 'Display Ledger Address':
+    case 'Display Ledger Address (only compatible with Ledger Generic App)':
       console.log(await getLedgerAddress());
       break;
     default:

--- a/multisigConfig.json
+++ b/multisigConfig.json
@@ -10,6 +10,7 @@
 	"threshold_note": "x from x of y signers",
 	"threshold": null,
 	"ledger_note": "if you are using a ledger to sign set as true",
-	"ledger": false
+	"ledger": false,
+	"migration": false
 }
  

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
   "author": "Jesse Abramowitz",
   "license": "MIT",
   "dependencies": {
-    "@ledgerhq/hw-transport-node-hid": "^6.27.21",
+    "@polkadot-api/merkleize-metadata": "^1.1.2",
     "@polkadot/api": "^12.3.1",
-    "@polkadot/hw-ledger": "^12.6.2",
+    "@polkadot/hw-ledger": "^13.0.2",
+    "@polkadot/networks": "^13.0.2",
+    "@polkadot/util": "^13.0.2",
     "@polkadot/util-crypto": "^13.0.2",
-    "@zondax/ledger-substrate": "^0.41.1",
     "inquirer": "^8.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -978,152 +978,110 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ledgerhq/devices@npm:^8.0.7":
-  version: 8.0.7
-  resolution: "@ledgerhq/devices@npm:8.0.7"
+"@ledgerhq/devices@npm:^8.3.0, @ledgerhq/devices@npm:^8.4.0, @ledgerhq/devices@npm:^8.4.2":
+  version: 8.4.2
+  resolution: "@ledgerhq/devices@npm:8.4.2"
   dependencies:
-    "@ledgerhq/errors": "npm:^6.14.0"
-    "@ledgerhq/logs": "npm:^6.10.1"
-    rxjs: "npm:6"
-    semver: "npm:^7.3.5"
-  checksum: 10c0/5a8bdde14f89ddc0152a5d3e786703cb705802fc8f9d8b94b658807eb30a9a524f3b255a6966bc82219fe26b765ca817a0c07e40e24a0c3a210f53185bae0437
-  languageName: node
-  linkType: hard
-
-"@ledgerhq/devices@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "@ledgerhq/devices@npm:8.2.0"
-  dependencies:
-    "@ledgerhq/errors": "npm:^6.16.1"
+    "@ledgerhq/errors": "npm:^6.18.0"
     "@ledgerhq/logs": "npm:^6.12.0"
     rxjs: "npm:^7.8.1"
     semver: "npm:^7.3.5"
-  checksum: 10c0/3c6706cd99295d6d14265376fe607ab72cf234b8a866aca910fb2340e2047989d74e771184423a59fed1a784437fb8feb8bea677852a62b0747d0eda0d65ca0e
+  checksum: 10c0/b7149c6302d23928fd2d3622d9018af10a56f6960732de0d72e881d19b75b0036f6248ca0845cfe9dfeda32ecb52c352423e79e109c7decf8437948fed7843cd
   languageName: node
   linkType: hard
 
-"@ledgerhq/errors@npm:^6.14.0":
-  version: 6.14.0
-  resolution: "@ledgerhq/errors@npm:6.14.0"
-  checksum: 10c0/e1505f1908234476a57c103c601435d75b17dde7a2f0ee74b28fcad55a56df1eeefa9bdedc4c290cf1eb0098e7aaf1ca659ec6db079d5671132c0aa6d3167660
+"@ledgerhq/errors@npm:^6.16.4, @ledgerhq/errors@npm:^6.17.0, @ledgerhq/errors@npm:^6.18.0":
+  version: 6.18.0
+  resolution: "@ledgerhq/errors@npm:6.18.0"
+  checksum: 10c0/0dad36bd049c1eb346b83d2b99c1dde0445c53ae3a2f73d4f9a7f5e278ef61d1e589cc0b30bb81dd3082ad9a751f7d82b662214088e19b09769bded45447fb54
   languageName: node
   linkType: hard
 
-"@ledgerhq/errors@npm:^6.16.1":
-  version: 6.16.1
-  resolution: "@ledgerhq/errors@npm:6.16.1"
-  checksum: 10c0/cabd4c2768be3f2eec9e15d83519b8eae113efb2d9f3dcd241e2ad01101f3a073dbf2eceae72073151db3bd36ab231d69b66b9aa4106c23ff5444185c66de849
-  languageName: node
-  linkType: hard
-
-"@ledgerhq/hw-transport-node-hid-noevents@npm:^6.27.19":
-  version: 6.27.19
-  resolution: "@ledgerhq/hw-transport-node-hid-noevents@npm:6.27.19"
-  dependencies:
-    "@ledgerhq/devices": "npm:^8.0.7"
-    "@ledgerhq/errors": "npm:^6.14.0"
-    "@ledgerhq/hw-transport": "npm:^6.28.8"
-    "@ledgerhq/logs": "npm:^6.10.1"
-    node-hid: "npm:^2.1.2"
-  checksum: 10c0/346b7d7396e714a96c5c52df524f76a72b1cf5e4f0df2ef6567dcdee077cb4d0326d245ebf0d92be173f008ff8b4b697ea4f0a05dc11e546a28f88bcbf3d9fce
-  languageName: node
-  linkType: hard
-
-"@ledgerhq/hw-transport-node-hid-noevents@npm:^6.29.3":
-  version: 6.29.3
-  resolution: "@ledgerhq/hw-transport-node-hid-noevents@npm:6.29.3"
-  dependencies:
-    "@ledgerhq/devices": "npm:^8.2.0"
-    "@ledgerhq/errors": "npm:^6.16.1"
-    "@ledgerhq/hw-transport": "npm:^6.30.3"
-    "@ledgerhq/logs": "npm:^6.12.0"
-    node-hid: "npm:^2.1.2"
-  checksum: 10c0/ee5bad5384dd39f41641cd55dae83a6e7e10c8c3a35da6ffcd37e5c10e625bf49f5aa0a8bbea1f1cc1dcf2f910bb27014563871825dea18ae943008d521bd1aa
-  languageName: node
-  linkType: hard
-
-"@ledgerhq/hw-transport-node-hid-singleton@npm:^6.30.1":
+"@ledgerhq/hw-transport-node-hid-noevents@npm:^6.30.3":
   version: 6.30.3
-  resolution: "@ledgerhq/hw-transport-node-hid-singleton@npm:6.30.3"
+  resolution: "@ledgerhq/hw-transport-node-hid-noevents@npm:6.30.3"
   dependencies:
-    "@ledgerhq/devices": "npm:^8.2.0"
-    "@ledgerhq/errors": "npm:^6.16.1"
-    "@ledgerhq/hw-transport": "npm:^6.30.3"
-    "@ledgerhq/hw-transport-node-hid-noevents": "npm:^6.29.3"
+    "@ledgerhq/devices": "npm:^8.4.2"
+    "@ledgerhq/errors": "npm:^6.18.0"
+    "@ledgerhq/hw-transport": "npm:^6.31.2"
     "@ledgerhq/logs": "npm:^6.12.0"
-    node-hid: "npm:^2.1.2"
+    node-hid: "npm:2.1.2"
+  checksum: 10c0/a86e8d7ce0243063223cee25ac35aca622e027334d7b7fe9432f7d36e232d3e6614fc58bc92a981144737c8c16f735b21ad48a4752dc9404c5a53c5797a6cdd4
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/hw-transport-node-hid-singleton@npm:^6.31.1":
+  version: 6.31.3
+  resolution: "@ledgerhq/hw-transport-node-hid-singleton@npm:6.31.3"
+  dependencies:
+    "@ledgerhq/devices": "npm:^8.4.2"
+    "@ledgerhq/errors": "npm:^6.18.0"
+    "@ledgerhq/hw-transport": "npm:^6.31.2"
+    "@ledgerhq/hw-transport-node-hid-noevents": "npm:^6.30.3"
+    "@ledgerhq/logs": "npm:^6.12.0"
+    node-hid: "npm:2.1.2"
     usb: "npm:2.9.0"
-  checksum: 10c0/b959a0c97744454dc10a3d9b4267f8a11e040950f0b3dab6418db816ca9c027946b67f4faf06ddf35c6cb4207ce1269f90a39a75528e98aabdbfb17c7ef5bc3a
+  checksum: 10c0/99bffa1173c8be460bb24d4013e214e71167d2b8b42443f0c93d859fc970712920dc6231e0aad93497b7d21917d447c297f3b1cdccf7170edb22cdb80c9412db
   languageName: node
   linkType: hard
 
-"@ledgerhq/hw-transport-node-hid@npm:^6.27.21":
-  version: 6.27.21
-  resolution: "@ledgerhq/hw-transport-node-hid@npm:6.27.21"
+"@ledgerhq/hw-transport-webhid@npm:^6.29.0":
+  version: 6.29.2
+  resolution: "@ledgerhq/hw-transport-webhid@npm:6.29.2"
   dependencies:
-    "@ledgerhq/devices": "npm:^8.0.7"
-    "@ledgerhq/errors": "npm:^6.14.0"
-    "@ledgerhq/hw-transport": "npm:^6.28.8"
-    "@ledgerhq/hw-transport-node-hid-noevents": "npm:^6.27.19"
-    "@ledgerhq/logs": "npm:^6.10.1"
-    lodash: "npm:^4.17.21"
-    node-hid: "npm:^2.1.2"
-    usb: "npm:2.9.0"
-  checksum: 10c0/d274c590e1a290672106a69a5a83e303526a2a74c9c2bf2de3e7590d4b45d3a8b98bdc8cf26d6b9d1970ee2cff2eb4c359fb34cd6e4f82bd03e2ab16fdd77cf3
-  languageName: node
-  linkType: hard
-
-"@ledgerhq/hw-transport-webhid@npm:^6.28.1":
-  version: 6.28.3
-  resolution: "@ledgerhq/hw-transport-webhid@npm:6.28.3"
-  dependencies:
-    "@ledgerhq/devices": "npm:^8.2.0"
-    "@ledgerhq/errors": "npm:^6.16.1"
-    "@ledgerhq/hw-transport": "npm:^6.30.3"
+    "@ledgerhq/devices": "npm:^8.4.2"
+    "@ledgerhq/errors": "npm:^6.18.0"
+    "@ledgerhq/hw-transport": "npm:^6.31.2"
     "@ledgerhq/logs": "npm:^6.12.0"
-  checksum: 10c0/b2017d283f2030e28ab663fc7f032db66ef3bfefb29ceb4cecf29561f7ed54f9e0c17c1e1e30a09ee9957ed8f1b8bada7391c4030554370a122a6654979600b8
+  checksum: 10c0/86a610bf99eb44fbd93a7d0afc621f13a5f43e63fc86c64f686f88cc528d0ea62a51f674b8a6148aaa4330cc8ef2c2b2e461bbea5a71ae39305f82124a83377b
   languageName: node
   linkType: hard
 
-"@ledgerhq/hw-transport-webusb@npm:^6.28.1":
-  version: 6.28.3
-  resolution: "@ledgerhq/hw-transport-webusb@npm:6.28.3"
+"@ledgerhq/hw-transport-webusb@npm:^6.29.0":
+  version: 6.29.2
+  resolution: "@ledgerhq/hw-transport-webusb@npm:6.29.2"
   dependencies:
-    "@ledgerhq/devices": "npm:^8.2.0"
-    "@ledgerhq/errors": "npm:^6.16.1"
-    "@ledgerhq/hw-transport": "npm:^6.30.3"
+    "@ledgerhq/devices": "npm:^8.4.2"
+    "@ledgerhq/errors": "npm:^6.18.0"
+    "@ledgerhq/hw-transport": "npm:^6.31.2"
     "@ledgerhq/logs": "npm:^6.12.0"
-  checksum: 10c0/5afa4eb4a21bd88628ddb6606a68946f4fb288126f6313595ec70be7238eee25af97a03c08954da1ab2473c00602f052fac32cdfc71d7af333beba63c75f308a
+  checksum: 10c0/6499398c90ccd1210d9a6b91846df49001b0de7b74a97a8df0020fc35f22b90f3b886499c5237cdf198e914a616f310ccd22238f5136df46699561f6dd2412ed
   languageName: node
   linkType: hard
 
-"@ledgerhq/hw-transport@npm:^6.27.1, @ledgerhq/hw-transport@npm:^6.28.8":
-  version: 6.28.8
-  resolution: "@ledgerhq/hw-transport@npm:6.28.8"
+"@ledgerhq/hw-transport@npm:6.30.6":
+  version: 6.30.6
+  resolution: "@ledgerhq/hw-transport@npm:6.30.6"
   dependencies:
-    "@ledgerhq/devices": "npm:^8.0.7"
-    "@ledgerhq/errors": "npm:^6.14.0"
-    events: "npm:^3.3.0"
-  checksum: 10c0/adf3b154cfc08b25b9eba7bad67877b2cbf3cd44514b82fccb5b75e2a67ec01802d7d4528c7f71c46d574860255e61545c216c1293f9eed59e8513f6858f42d5
-  languageName: node
-  linkType: hard
-
-"@ledgerhq/hw-transport@npm:^6.30.1, @ledgerhq/hw-transport@npm:^6.30.3":
-  version: 6.30.3
-  resolution: "@ledgerhq/hw-transport@npm:6.30.3"
-  dependencies:
-    "@ledgerhq/devices": "npm:^8.2.0"
-    "@ledgerhq/errors": "npm:^6.16.1"
+    "@ledgerhq/devices": "npm:^8.3.0"
+    "@ledgerhq/errors": "npm:^6.16.4"
     "@ledgerhq/logs": "npm:^6.12.0"
     events: "npm:^3.3.0"
-  checksum: 10c0/e50b9f99d6127b641d293d33b5141f55e59a8a14afb231e7d5c696e234a210ca94a6573a442548384ac4afa315b60b9c3ff7cff29f3df5e00f9cb59385801d70
+  checksum: 10c0/85dc3e4938f921996821fbb0ce65808b210823f53aeeb98fb3537348cebab0c852702dca72a3d763b58b9362257d0f16f76930bacd8cc594ee5cd3d367836fda
   languageName: node
   linkType: hard
 
-"@ledgerhq/logs@npm:^6.10.1":
-  version: 6.10.1
-  resolution: "@ledgerhq/logs@npm:6.10.1"
-  checksum: 10c0/49cfb88b30a52f14445666df6ab7afd24d6df95fbfd52a05debaa3cd5d9156e366672311e4905873c6f2aa096fbfe2874560ad028796c2f4d64de49d9f037fb4
+"@ledgerhq/hw-transport@npm:6.31.0":
+  version: 6.31.0
+  resolution: "@ledgerhq/hw-transport@npm:6.31.0"
+  dependencies:
+    "@ledgerhq/devices": "npm:^8.4.0"
+    "@ledgerhq/errors": "npm:^6.17.0"
+    "@ledgerhq/logs": "npm:^6.12.0"
+    events: "npm:^3.3.0"
+  checksum: 10c0/6d277a05eb5a202a17a7a942e63022ae26321795c640d59a75b032e33274c731da5f23fbf00132efa57bc715bea8505d6a1293c20b121d603459b25c1d784444
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/hw-transport@npm:^6.31.0, @ledgerhq/hw-transport@npm:^6.31.2":
+  version: 6.31.2
+  resolution: "@ledgerhq/hw-transport@npm:6.31.2"
+  dependencies:
+    "@ledgerhq/devices": "npm:^8.4.2"
+    "@ledgerhq/errors": "npm:^6.18.0"
+    "@ledgerhq/logs": "npm:^6.12.0"
+    events: "npm:^3.3.0"
+  checksum: 10c0/3fc61c2e844639b7ec73e5eaec2f34235a414ec802df2491ea3d32d854f5f53c592b35b874a9ce899a6087a74a5a750b20c91aae19aaa44eea2faa390edf593f
   languageName: node
   linkType: hard
 
@@ -1198,7 +1156,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.3.2, @noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.3.2":
+"@noble/hashes@npm:1.3.2, @noble/hashes@npm:^1.3.2":
   version: 1.3.2
   resolution: "@noble/hashes@npm:1.3.2"
   checksum: 10c0/2482cce3bce6a596626f94ca296e21378e7a5d4c09597cbc46e65ffacc3d64c8df73111f2265444e36a3168208628258bbbaccba2ef24f65f58b2417638a20e7
@@ -1212,7 +1170,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:^1.3.1":
+"@noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.4.0":
   version: 1.4.0
   resolution: "@noble/hashes@npm:1.4.0"
   checksum: 10c0/8c3f005ee72e7b8f9cff756dfae1241485187254e3f743873e22073d63906863df5d4f13d441b7530ea614b7a093f0d889309f28b59850f33b66cb26a779a4a5
@@ -1387,6 +1345,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot-api/merkleize-metadata@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@polkadot-api/merkleize-metadata@npm:1.1.2"
+  dependencies:
+    "@polkadot-api/substrate-bindings": "npm:0.6.2"
+    "@polkadot-api/utils": "npm:0.1.1"
+  checksum: 10c0/4148c26c2d07b72ec1f632bfe683017131e9fa6a1dae2be9c32f3ae994392b98abd30e7175049a90d760e37362ec64872edb8a712f21d5a26baaf19b13dde5f2
+  languageName: node
+  linkType: hard
+
 "@polkadot-api/metadata-builders@npm:0.0.1":
   version: 0.0.1
   resolution: "@polkadot-api/metadata-builders@npm:0.0.1"
@@ -1445,6 +1413,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot-api/substrate-bindings@npm:0.6.2":
+  version: 0.6.2
+  resolution: "@polkadot-api/substrate-bindings@npm:0.6.2"
+  dependencies:
+    "@noble/hashes": "npm:^1.4.0"
+    "@polkadot-api/utils": "npm:0.1.1"
+    "@scure/base": "npm:^1.1.7"
+    scale-ts: "npm:^1.6.0"
+  checksum: 10c0/a96bb28aa28ac8ea94e8c8d13ecda0bbb39401007987789bcbbbc48caa5c3af772c4ca1a0200b218af4d8ddcf5424821e97bbbeacb6b1aac3b2f47a676d24242
+  languageName: node
+  linkType: hard
+
 "@polkadot-api/substrate-client@npm:0.0.1":
   version: 0.0.1
   resolution: "@polkadot-api/substrate-client@npm:0.0.1"
@@ -1470,6 +1450,13 @@ __metadata:
   version: 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
   resolution: "@polkadot-api/utils@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
   checksum: 10c0/63c36ac45d63a4f8718d1324be0290dadfbfbb387e440d5962de13200861400a6af09a5e96b73f985fd4c27d03c93927420c8145e49e1e822653a3c223dda645
+  languageName: node
+  linkType: hard
+
+"@polkadot-api/utils@npm:0.1.1":
+  version: 0.1.1
+  resolution: "@polkadot-api/utils@npm:0.1.1"
+  checksum: 10c0/25e4da0e2defb713d18cd0c0db594a89cc4e23f36b2ebc5bccb1e2a8ba9a9814d09630d577b98ebcfdbbda2861fa8be48e914bf5f461481f3a09f1627ea6e784
   languageName: node
   linkType: hard
 
@@ -1882,32 +1869,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/hw-ledger-transports@npm:12.6.2":
-  version: 12.6.2
-  resolution: "@polkadot/hw-ledger-transports@npm:12.6.2"
+"@polkadot/hw-ledger-transports@npm:13.0.2":
+  version: 13.0.2
+  resolution: "@polkadot/hw-ledger-transports@npm:13.0.2"
   dependencies:
-    "@ledgerhq/hw-transport": "npm:^6.30.1"
-    "@ledgerhq/hw-transport-node-hid-singleton": "npm:^6.30.1"
-    "@ledgerhq/hw-transport-webhid": "npm:^6.28.1"
-    "@ledgerhq/hw-transport-webusb": "npm:^6.28.1"
-    "@polkadot/util": "npm:12.6.2"
+    "@ledgerhq/hw-transport": "npm:^6.31.0"
+    "@ledgerhq/hw-transport-node-hid-singleton": "npm:^6.31.1"
+    "@ledgerhq/hw-transport-webhid": "npm:^6.29.0"
+    "@ledgerhq/hw-transport-webusb": "npm:^6.29.0"
+    "@polkadot/util": "npm:13.0.2"
     tslib: "npm:^2.6.2"
   dependenciesMeta:
     "@ledgerhq/hw-transport-node-hid-singleton":
       optional: true
-  checksum: 10c0/93eb9bba8ac93d6a42da53b10a624e6f4cedc13176c7b6d93f4cb78c44497e6b24eeddf13c2ecec55736e36d714ca9a4dabe03b2d7f2fb28734d202f7851fcbf
+  checksum: 10c0/af30bced081efda8f6886e9c38485543c89340c40fde6e713724e66036b057acc3f113361fdc1076d9c5ad2b97cb4b1340d062e1e097618558464567e75899b5
   languageName: node
   linkType: hard
 
-"@polkadot/hw-ledger@npm:^12.6.2":
-  version: 12.6.2
-  resolution: "@polkadot/hw-ledger@npm:12.6.2"
+"@polkadot/hw-ledger@npm:^13.0.2":
+  version: 13.0.2
+  resolution: "@polkadot/hw-ledger@npm:13.0.2"
   dependencies:
-    "@polkadot/hw-ledger-transports": "npm:12.6.2"
-    "@polkadot/util": "npm:12.6.2"
-    "@zondax/ledger-substrate": "npm:^0.41.3"
+    "@polkadot/hw-ledger-transports": "npm:13.0.2"
+    "@polkadot/util": "npm:13.0.2"
+    "@zondax/ledger-substrate": "npm:0.44.7"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/744db580208b9d1cd024d3f0d08b7eed9d5cb045aae0c2ba121b379b51c323564e9bc6547882e832cd2c2e46cade2d73c0e8ccb7fa90955cba467eb151013cda
+  checksum: 10c0/9eca54b14334e6058e8dc754491bc0c2534d30f8bfe5ff2d9cc647ed025c91a37750773370518342168521c33b2c60e9a74eda668d866c6a84efe16f0d0f8a95
   languageName: node
   linkType: hard
 
@@ -3881,6 +3868,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@scure/base@npm:^1.1.7":
+  version: 1.1.7
+  resolution: "@scure/base@npm:1.1.7"
+  checksum: 10c0/2d06aaf39e6de4b9640eb40d2e5419176ebfe911597856dcbf3bc6209277ddb83f4b4b02cb1fd1208f819654268ec083da68111d3530bbde07bae913e2fc2e5d
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.27.8":
   version: 0.27.8
   resolution: "@sinclair/typebox@npm:0.27.8"
@@ -4532,20 +4526,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zondax/ledger-substrate@npm:^0.41.1, @zondax/ledger-substrate@npm:^0.41.3":
-  version: 0.41.3
-  resolution: "@zondax/ledger-substrate@npm:0.41.3"
+"@zondax/ledger-js@npm:^0.8.2":
+  version: 0.8.2
+  resolution: "@zondax/ledger-js@npm:0.8.2"
   dependencies:
-    "@ledgerhq/hw-transport": "npm:^6.27.1"
-    bip32: "npm:^4.0.0"
-    bip32-ed25519: "git+https://github.com/Zondax/bip32-ed25519.git"
-    bip39: "npm:^3.0.4"
-    blakejs: "npm:^1.2.1"
-    bs58: "npm:^5.0.0"
-    hash.js: "npm:^1.1.7"
-  bin:
-    ledger-substrate: dist/cmd/cli.js
-  checksum: 10c0/fc1c3ce3e1b169be3dae05c5fbaf8e89bed709a4c25abceaff3c9f5f7938d4340834bb4ac21a43e67c3b603368f69486c3476f7378855dd99164d837d8c1a207
+    "@ledgerhq/hw-transport": "npm:6.30.6"
+  checksum: 10c0/93c4e241dc37098a66829561fa6d8f62daa2b2c70ce51d1134c1ec4a74b38e22044fc764882f9a195f1f6d3a3a4879182978aead8aa7b4dbc4fe398163b5b96b
+  languageName: node
+  linkType: hard
+
+"@zondax/ledger-substrate@npm:0.44.7":
+  version: 0.44.7
+  resolution: "@zondax/ledger-substrate@npm:0.44.7"
+  dependencies:
+    "@ledgerhq/hw-transport": "npm:6.31.0"
+    "@zondax/ledger-js": "npm:^0.8.2"
+    axios: "npm:^1.7.2"
+  checksum: 10c0/f5cf07ae8671b449bf787e21f226fc9c0ac1ed0cc68a5f42e7d4c55b9f9738f2e3c277a4b3eff2cfb66d4664ad7d150eb08156df3fbbcb80b4f5129ac1a659a2
   languageName: node
   linkType: hard
 
@@ -4737,14 +4734,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "asset_cli_tool@workspace:."
   dependencies:
-    "@ledgerhq/hw-transport-node-hid": "npm:^6.27.21"
+    "@polkadot-api/merkleize-metadata": "npm:^1.1.2"
     "@polkadot/api": "npm:^12.3.1"
     "@polkadot/apps-config": "npm:^0.142.1"
-    "@polkadot/hw-ledger": "npm:^12.6.2"
+    "@polkadot/hw-ledger": "npm:^13.0.2"
+    "@polkadot/networks": "npm:^13.0.2"
+    "@polkadot/util": "npm:^13.0.2"
     "@polkadot/util-crypto": "npm:^13.0.2"
     "@substrate/dev": "npm:^0.7.0"
     "@types/node": "npm:^20.6.3"
-    "@zondax/ledger-substrate": "npm:^0.41.1"
     inquirer: "npm:^8.0.0"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.2.2"
@@ -4755,6 +4753,17 @@ __metadata:
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
   checksum: 10c0/d73e2ddf20c4eb9337e1b3df1a0f6159481050a5de457c55b14ea2e5cb6d90bb69e004c9af54737a5ee0917fcf2c9e25de67777bbe58261847846066ba75bc9d
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.7.2":
+  version: 1.7.3
+  resolution: "axios@npm:1.7.3"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.0"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/a18cbe559203efa05fb1fec2d1898e23bf6329bd2575784ee32aa11b5bbe1d54b9f472c49a261294125519cf62aa4fe5ef6e647bb7482eafc15bffe15ab314ce
   languageName: node
   linkType: hard
 
@@ -4841,19 +4850,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-x@npm:^3.0.2, base-x@npm:^3.0.8":
+"base-x@npm:^3.0.8":
   version: 3.0.9
   resolution: "base-x@npm:3.0.9"
   dependencies:
     safe-buffer: "npm:^5.0.1"
   checksum: 10c0/e6bbeae30b24f748b546005affb710c5fbc8b11a83f6cd0ca999bd1ab7ad3a22e42888addc40cd145adc4edfe62fcfab4ebc91da22e4259aae441f95a77aee1a
-  languageName: node
-  linkType: hard
-
-"base-x@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "base-x@npm:4.0.0"
-  checksum: 10c0/0cb47c94535144ab138f70bb5aa7e6e03049ead88615316b62457f110fc204f2c3baff5c64a1c1b33aeb068d79a68092c08a765c7ccfa133eee1e70e4c6eb903
   languageName: node
   linkType: hard
 
@@ -4873,38 +4875,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bip32-ed25519@git+https://github.com/Zondax/bip32-ed25519.git":
-  version: 0.0.4
-  resolution: "bip32-ed25519@https://github.com/Zondax/bip32-ed25519.git#commit=0949df01b5c93885339bc28116690292088f6134"
-  dependencies:
-    bn.js: "npm:^5.1.1"
-    elliptic: "npm:^6.4.1"
-    hash.js: "npm:^1.1.7"
-  checksum: 10c0/2b2a4ec296a2594e4d49b449c8f3bb839d19529fce34b9e9d5bb6c7a2c3041491f5430e89968053439ef4fe755af04fcc00953d1ca3bcf26d6981163d3b0f2c7
-  languageName: node
-  linkType: hard
-
-"bip32@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "bip32@npm:4.0.0"
-  dependencies:
-    "@noble/hashes": "npm:^1.2.0"
-    "@scure/base": "npm:^1.1.1"
-    typeforce: "npm:^1.11.5"
-    wif: "npm:^2.0.6"
-  checksum: 10c0/b74ffd3a96b42a783eca6455dff8f0decc8360025b69d486d5a047b52cca6e8436bc5a9812cbeae2638a50f35da7fcd85b55cfe58272f55a5b31d7ac40a25522
-  languageName: node
-  linkType: hard
-
-"bip39@npm:^3.0.4":
-  version: 3.1.0
-  resolution: "bip39@npm:3.1.0"
-  dependencies:
-    "@noble/hashes": "npm:^1.2.0"
-  checksum: 10c0/68f9673a0d6a851e9635f3af8a85f2a1ecef9066c76d77e6f0d58d274b5bf22a67f429da3997e07c0d2cf153a4d7321f9273e656cac0526f667575ddee28ef71
-  languageName: node
-  linkType: hard
-
 "bl@npm:^4.0.3, bl@npm:^4.1.0":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
@@ -4916,7 +4886,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"blakejs@npm:^1.1.1, blakejs@npm:^1.2.1":
+"blakejs@npm:^1.1.1":
   version: 1.2.1
   resolution: "blakejs@npm:1.2.1"
   checksum: 10c0/c284557ce55b9c70203f59d381f1b85372ef08ee616a90162174d1291a45d3e5e809fdf9edab6e998740012538515152471dc4f1f9dbfa974ba2b9c1f7b9aad7
@@ -4930,7 +4900,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^5.1.1, bn.js@npm:^5.2.0, bn.js@npm:^5.2.1":
+"bn.js@npm:^5.2.0, bn.js@npm:^5.2.1":
   version: 5.2.1
   resolution: "bn.js@npm:5.2.1"
   checksum: 10c0/bed3d8bd34ec89dbcf9f20f88bd7d4a49c160fda3b561c7bb227501f974d3e435a48fb9b61bc3de304acab9215a3bda0803f7017ffb4d0016a0c3a740a283caa
@@ -4992,35 +4962,6 @@ __metadata:
   dependencies:
     fast-json-stable-stringify: "npm:2.x"
   checksum: 10c0/80e89aaaed4b68e3374ce936f2eb097456a0dddbf11f75238dbd53140b1e39259f0d248a5089ed456f1158984f22191c3658d54a713982f676709fbe1a6fa5a0
-  languageName: node
-  linkType: hard
-
-"bs58@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "bs58@npm:4.0.1"
-  dependencies:
-    base-x: "npm:^3.0.2"
-  checksum: 10c0/613a1b1441e754279a0e3f44d1faeb8c8e838feef81e550efe174ff021dd2e08a4c9ae5805b52dfdde79f97b5c0918c78dd24a0eb726c4a94365f0984a0ffc65
-  languageName: node
-  linkType: hard
-
-"bs58@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "bs58@npm:5.0.0"
-  dependencies:
-    base-x: "npm:^4.0.0"
-  checksum: 10c0/0d1b05630b11db48039421b5975cb2636ae0a42c62f770eec257b2e5c7d94cb5f015f440785f3ec50870a6e9b1132b35bd0a17c7223655b22229f24b2a3491d1
-  languageName: node
-  linkType: hard
-
-"bs58check@npm:<3.0.0":
-  version: 2.1.2
-  resolution: "bs58check@npm:2.1.2"
-  dependencies:
-    bs58: "npm:^4.0.0"
-    create-hash: "npm:^1.1.0"
-    safe-buffer: "npm:^5.1.2"
-  checksum: 10c0/5d33f319f0d7abbe1db786f13f4256c62a076bc8d184965444cb62ca4206b2c92bee58c93bce57150ffbbbe00c48838ac02e6f384e0da8215cac219c0556baa9
   languageName: node
   linkType: hard
 
@@ -5363,7 +5304,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-hash@npm:^1.1.0, create-hash@npm:^1.2.0":
+"create-hash@npm:^1.2.0":
   version: 1.2.0
   resolution: "create-hash@npm:1.2.0"
   dependencies:
@@ -5615,7 +5556,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:^6.4.1, elliptic@npm:^6.5.4":
+"elliptic@npm:^6.5.4":
   version: 6.5.4
   resolution: "elliptic@npm:6.5.4"
   dependencies:
@@ -6170,6 +6111,16 @@ __metadata:
   version: 3.2.9
   resolution: "flatted@npm:3.2.9"
   checksum: 10c0/5c91c5a0a21bbc0b07b272231e5b4efe6b822bcb4ad317caf6bb06984be4042a9e9045026307da0fdb4583f1f545e317a67ef1231a59e71f7fced3cc429cfc53
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.15.6":
+  version: 1.15.6
+  resolution: "follow-redirects@npm:1.15.6"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 10c0/9ff767f0d7be6aa6870c82ac79cf0368cd73e01bbc00e9eb1c2a16fbb198ec105e3c9b6628bb98e9f3ac66fe29a957b9645bcb9a490bb7aa0d35f908b6b85071
   languageName: node
   linkType: hard
 
@@ -7980,7 +7931,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-hid@npm:^2.1.2":
+"node-hid@npm:2.1.2":
   version: 2.1.2
   resolution: "node-hid@npm:2.1.2"
   dependencies:
@@ -8397,6 +8348,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
+  languageName: node
+  linkType: hard
+
 "pump@npm:^3.0.0":
   version: 3.0.0
   resolution: "pump@npm:3.0.0"
@@ -8610,7 +8568,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:6, rxjs@npm:^6.6.7":
+"rxjs@npm:^6.6.7":
   version: 6.6.7
   resolution: "rxjs@npm:6.6.7"
   dependencies:
@@ -9297,13 +9255,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typeforce@npm:^1.11.5":
-  version: 1.18.0
-  resolution: "typeforce@npm:1.18.0"
-  checksum: 10c0/011f57effd9ae6d3dd8bb249e09b4ecadb2c2a3f803b27f977ac8b7782834855930bff971ba549bcd5a8cedc8136d8a977c0b7e050cc67deded948181b7ba3e8
-  languageName: node
-  linkType: hard
-
 "typescript@npm:^4.4.3, typescript@npm:^4.7.4":
   version: 4.9.5
   resolution: "typescript@npm:4.9.5"
@@ -9514,15 +9465,6 @@ __metadata:
   dependencies:
     string-width: "npm:^1.0.2 || 2 || 3 || 4"
   checksum: 10c0/1d9c2a3e36dfb09832f38e2e699c367ef190f96b82c71f809bc0822c306f5379df87bab47bed27ea99106d86447e50eb972d3c516c2f95782807a9d082fbea95
-  languageName: node
-  linkType: hard
-
-"wif@npm:^2.0.6":
-  version: 2.0.6
-  resolution: "wif@npm:2.0.6"
-  dependencies:
-    bs58check: "npm:<3.0.0"
-  checksum: 10c0/9ff55fdde73226bbae6a08b68298b6d14bbc22fa4cefac11edaacb2317c217700f715b95dc4432917f73511ec983f1bc032d22c467703b136f4e6ca7dfa9f10b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update the signing options that use Ledger to work with both the Generic App or the Migration App.

Notes:

- `getLedgerAddress()` now only works with the Ledger Generic App, it could be made to work with both with quite a bit of changes, but don't know if it's worth it
- I removed `@zondax/ledger-substrate` and `@ledgerhq/hw-transport-node-hid` since I couldn't find where they were used.

TODO:

- [x] More testing